### PR TITLE
Update navbar.blade.php

### DIFF
--- a/resources/views/admin/partials/navbar.blade.php
+++ b/resources/views/admin/partials/navbar.blade.php
@@ -1,6 +1,6 @@
  <!-- Static navbar -->
     <nav class="navbar navbar-default navbar-static-top navbar-inverse">
-      <div class="container">
+      <div class="container-fluid">
         <div class="navbar-header">
           <!-- <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
             <span class="sr-only">Toggle navigation</span>


### PR DESCRIPTION
将第三行的class改为container-fluid，以下是container和container-fluid区别：
1、根据官方文档(http://getbootstrap.com/css/)，container用于响应式布局，不同尺寸屏幕被固定设置了不同宽度，并且由于左右margin(margin-left,margin-right）设置为auto，所以左右margin会自动调整，并且等于(屏幕总宽度-被设置的container宽度)/2。所以因为有左右margin的存在你的navbar-header里的navbar-brand不能紧靠左侧。这是我电脑把容器设置为container时显示的css:
@media (min-width: 1200px)
.container {
    width: 1170px;
}
@media (min-width: 992px)
.container {
    width: 970px;
}
@media (min-width: 768px)
.container {
    width: 750px;
}
.container {
    padding-right: 15px;
    padding-left: 15px;
    margin-right: auto;
    margin-left: auto;
}
可以看出容器宽度是固定的，所以存在左右边距。
2、当把容器设置为container-fluid时，此时会容器宽度为整个屏幕宽度，没有左右margin，即左右margin为0。以下是我把容器设置为container-fluid时浏览器解析的css样式：
.container-fluid {
    padding-right: 15px;
    padding-left: 15px;
    margin-right: auto;
    margin-left: auto;
}
当某个div或者其他块级框宽度没有设置，并且左右margin为auto时，这个块级框width就是父容器的宽度，这里就是屏幕宽度。所以当设置container-fluid时，宽度是full width container。